### PR TITLE
fix: fix issue where memoization constantly gets overwritten due to it being set in global level

### DIFF
--- a/src/client/__tests__/usePrefetch.spec.js
+++ b/src/client/__tests__/usePrefetch.spec.js
@@ -2,11 +2,11 @@ import React, { useEffect } from "react";
 import { render, waitFor, fireEvent } from "@testing-library/react";
 import usePrefetch from "../usePrefetch";
 import { PrefetchProvider } from "../../context";
-import { oneOfType, number, string } from "prop-types";
+import { oneOfType, number, string, node, bool, object } from "prop-types";
 
-const defaultProps = {};
 
 const mockNewsStory = "this is a story with id: ";
+const mockWeatherStory = "this is a weather with id: ";
 const prefetchFunctions = {
   news: jest
     .fn()
@@ -14,103 +14,251 @@ const prefetchFunctions = {
     .mockImplementation((newsID) =>
       newsID
         ? Promise.resolve({
-            story: mockNewsStory + newsID,
-          })
+          story: mockNewsStory + newsID,
+        })
         : Promise.reject("no newsID provided")
     ),
 };
 const loadingComponent = "Loading";
 const errorComponent = "Error Occured";
+const defaultProps = {
+  loadingComponent: loadingComponent,
+  errorComponent: errorComponent,
+};
 
 describe("usePrefetch behaviour", () => {
-  // for rerendering
-  const getCmp = (props = {}, initialData = {}) => {
-    const Cmp = ({ newsID }) => {
-      const params = { news: [newsID] };
-      const {
-        news: { data, loading, error },
-      } = usePrefetch(prefetchFunctions, { params });
-      if (loading) return <div>{loadingComponent}</div>;
-      if (error) return <div>{errorComponent}</div>;
-      return <div>{data.story}</div>;
-    };
-
-    Cmp.propTypes = {
-      newsID: oneOfType([number, string]),
-    };
-
-    return (
-      <PrefetchProvider data={initialData}>
-        <Cmp {...defaultProps} {...props} />;
-      </PrefetchProvider>
-    );
+  const BaseCmp = ({ loadingComponent, errorComponent, loading, data, error }) => {
+    if (loading) return <div>{loadingComponent}</div>;
+    if (error) return <div>{errorComponent}</div>;
+    return <div>{JSON.stringify(data)}</div>;
   };
 
-  const setup = (props = {}, initialData = {}) => {
-    return render(getCmp(props, initialData));
+  BaseCmp.propTypes = {
+    loadingComponent: node.isRequired,
+    errorComponent: node.isRequired,
+    loading: bool.isRequired,
+    data: object,
+    error: oneOfType([string, object]),
   };
-
   beforeEach(() => {
-    prefetchFunctions.news.mockClear();
+    jest.clearAllMocks();
   });
-  describe("testing without initial data", () => {
-    it("should start with loading state, then renders data", async () => {
-      const props = {
-        newsID: 1,
-      };
-      const { getByText, rerender } = setup(props);
-      expect(getByText(loadingComponent)).toBeTruthy();
-      const { story } = await prefetchFunctions.news(props.newsID);
-      waitFor(() => {
-        expect(getByText(story)).toBeTruthy();
-      });
+  describe('single usePrefetch usage', () => {
+    // for rerendering
+    const getCmp = (props = {}, initialData = {}) => {
 
-      // test changing params
-      const secondProps = {
-        newsID: 2,
+      const Cmp = ({ newsID }) => {
+        const params = { news: [newsID] };
+        const {
+          news,
+        } = usePrefetch(prefetchFunctions, { params });
+        return <BaseCmp {...news} loadingComponent={loadingComponent} errorComponent={errorComponent} />
       };
 
-      rerender(getCmp(secondProps));
-      const { story: secondStory } = await prefetchFunctions.news(
-        secondProps.newsID
+      Cmp.propTypes = {
+        newsID: oneOfType([number, string]),
+      };
+
+      return (
+        <PrefetchProvider data={initialData}>
+          <Cmp {...defaultProps} {...props} />;
+        </PrefetchProvider>
       );
-      waitFor(() => {
-        expect(getByText(secondStory)).toBeTruthy();
+    };
+
+    const setup = (props = {}, initialData = {}) => {
+      return render(getCmp(props, initialData));
+    };
+
+    describe("testing without initial data", () => {
+      it("should start with loading state, then renders data", async () => {
+        const props = {
+          newsID: 1,
+        };
+        const { getByText } = setup(props);
+        expect(getByText(loadingComponent)).toBeTruthy();
+        await waitFor(() => {
+          expect(prefetchFunctions.news).toHaveBeenCalledTimes(1);
+          expect(getByText(new RegExp(mockNewsStory+props.newsID, 'i'))).toBeTruthy();
+        });
       });
 
-      // test changing error params
-      const errorProps = {};
+      test("rerendering usePrefetch with different params", async () => {
+        const props = {
+          newsID: 1,
+        };
+        const { getByText, rerender } = setup(props);
+        expect(getByText(loadingComponent)).toBeTruthy();
+        await waitFor(() => {
+          expect(prefetchFunctions.news).toHaveBeenCalledTimes(1);
+          expect(getByText(new RegExp(mockNewsStory+props.newsID, 'i'))).toBeTruthy();
+        });
 
-      rerender(getCmp(errorProps));
-      waitFor(() => {
-        expect(getByText(errorComponent)).toBeTruthy();
-      });
-    });
-
-    it("should render error", () => {
-      const props = {};
-      const { getByText } = setup(props);
-
-      waitFor(() => {
-        expect(getByText(errorComponent)).toBeTruthy();
-      });
-    });
-
-    describe("testing with initial data", () => {
-      it("should render data without loading", () => {
-        const initialNewsData = "some-story";
-        const initialData = {
-          news: { data: { story: initialNewsData } },
+        // test changing params
+        const secondProps = {
+          newsID: 2,
         };
 
+        rerender(getCmp(secondProps));
+        await waitFor(() => {
+          expect(prefetchFunctions.news).toHaveBeenCalledTimes(2);
+          expect(getByText(new RegExp(mockNewsStory+secondProps.newsID, 'i'))).toBeTruthy();
+        });
+
+        // test changing error params
+        const errorProps = {};
+
+        rerender(getCmp(errorProps));
+        await waitFor(() => {
+          expect(prefetchFunctions.news).toHaveBeenCalledTimes(3);
+          expect(getByText(new RegExp(errorComponent, 'i'))).toBeTruthy();
+        });
+      });
+
+      test("render with no data & error when fetching", async () => {
         const props = {};
-        const { queryByText, getByText } = setup(props, initialData);
-        expect(queryByText(loadingComponent)).toBeNull();
-        expect(getByText(initialNewsData)).toBeTruthy();
+        const { getByText } = setup(props);
+
+        await waitFor(() => {
+          expect(getByText(errorComponent)).toBeTruthy();
+        });
+      });
+
+      describe("testing with initial data", () => {
+        it("should render data without loading", () => {
+          const initialNewsData = "some-story";
+          const initialData = {
+            news: { data: { story: initialNewsData } },
+          };
+
+          const props = {};
+          const { queryByText, getByText } = setup(props, initialData);
+          expect(queryByText(loadingComponent)).toBeNull();
+          expect(getByText(new RegExp(initialNewsData, 'i'))).toBeTruthy();
+        });
       });
     });
-  });
+  })
+
+  describe('multiple usePrefetch usage in one component', () => {
+    const newsPrefetchFunctions = {
+      news: jest
+        .fn()
+        .mockName("mock-prefetch-news")
+        .mockImplementation((newsID) =>
+          newsID
+            ? Promise.resolve({
+              story: mockNewsStory + newsID,
+            })
+            : Promise.reject("no newsID provided")
+        ),
+    };
+    const weatherPrefetchFunctions = {
+      weather: jest
+        .fn()
+        .mockName("mock-prefetch-weather")
+        .mockImplementation((weatherID) =>
+          weatherID
+            ? Promise.resolve({
+              story: mockWeatherStory + weatherID,
+            })
+            : Promise.reject("no weatherID provided")
+        ),
+    };
+    describe('multiple usePrefetch in one component', () => {
+      const newsLoader = 'news' + loadingComponent;
+      const newsError = 'news' + errorComponent;
+      const weatherLoader = 'weather' + loadingComponent;
+      const weatherError = 'weather' + errorComponent;
+      const getCmp = (props = {}, initialData = {}) => {
+        const Cmp = ({ newsID, weatherID }) => {
+          const newsParams = { news: [newsID] };
+          const weatherParams = { weather: [weatherID] };
+          const {
+            news,
+          } = usePrefetch(newsPrefetchFunctions, { params: newsParams });
+          const {
+            weather,
+          } = usePrefetch(weatherPrefetchFunctions, { params: weatherParams });
+          return (<div>
+            <BaseCmp {...news} loadingComponent={newsLoader} errorComponent={newsError} />
+            <BaseCmp {...weather} loadingComponent={weatherLoader} errorComponent={weatherError} />
+          </div>)
+        };
+
+        Cmp.propTypes = {
+          newsID: oneOfType([number, string]),
+          weatherID: oneOfType([number, string]),
+        };
+
+        return (
+          <PrefetchProvider data={initialData}>
+            <Cmp {...defaultProps} {...props} />;
+          </PrefetchProvider>
+        );
+      }
+
+      const setup = (props = {}, initialData = {}) => {
+        return render(getCmp(props, initialData));
+      }
+
+      describe("testing without initial data", () => {
+        it("should start with loading state, then renders data", async () => {
+          const props = {
+            newsID: 1,
+            weatherID: 2,
+          };
+
+          const { getByText } = setup(props);
+          expect(getByText(new RegExp(newsLoader, 'i'))).toBeTruthy();
+          expect(getByText(new RegExp(weatherLoader, 'i'))).toBeTruthy();
+          await waitFor(() => {
+            expect(weatherPrefetchFunctions.weather).toHaveBeenCalledTimes(1);
+            expect(newsPrefetchFunctions.news).toHaveBeenCalledTimes(1);
+            expect(getByText(new RegExp(mockNewsStory + props.newsID, 'i'))).toBeTruthy();
+            expect(getByText(new RegExp(mockWeatherStory + props.weatherID, 'i'))).toBeTruthy();
+          });
+        });
+
+        it("should render both success & error fetch", async () => {
+          const props = {
+            weatherID: 5,
+          };
+          const { getByText } = setup(props);
+          await waitFor(() => {
+            expect(weatherPrefetchFunctions.weather).toHaveBeenCalledTimes(1);
+            expect(newsPrefetchFunctions.news).toHaveBeenCalledTimes(1);
+            expect(getByText(new RegExp(newsError, 'i'))).toBeTruthy();
+            expect(getByText(new RegExp(mockWeatherStory + props.weatherID, 'i'))).toBeTruthy();
+          });
+        });
+
+        describe("testing with initial data", () => {
+          it("should render data without loading", async () => {
+            const initialNewsData = "some-story";
+            const initialData = {
+              news: { data: { story: initialNewsData } },
+              weather: { data: { story: mockWeatherStory + 1 } },
+            };
+
+            const props = {};
+            const { queryByText, getByText } = setup(props, initialData);
+            expect(queryByText(new RegExp(newsLoader, 'i'))).toBeNull();
+            expect(queryByText(new RegExp(weatherLoader, 'i'))).toBeNull();
+            expect(getByText(new RegExp(initialNewsData, 'i'))).toBeTruthy();
+            expect(getByText(new RegExp(mockWeatherStory + 1, 'i'))).toBeTruthy();
+
+            await waitFor(() => {
+              expect(weatherPrefetchFunctions.weather).not.toHaveBeenCalled();
+              expect(newsPrefetchFunctions.news).not.toHaveBeenCalled();
+            })
+          });
+        });
+      });
+    })
+  })
 });
+
 
 // TODO: refetch is still a bit buggy
 describe.skip("refetching behaviour", () => {

--- a/src/client/usePrefetch.js
+++ b/src/client/usePrefetch.js
@@ -1,4 +1,4 @@
-import { useState, useContext, useMemo, useEffect } from "react";
+import { useState, useContext, useMemo, useEffect, useRef } from "react";
 import { getPrefetchContext } from "../context";
 import deepEqual from "@wry/equality";
 
@@ -14,9 +14,10 @@ function usePrefetch(
     lazy = false,
   } = {}
 ) {
-  let { data: prefetchedData, requests, memo } = useContext(
+  let { data: prefetchedData, requests } = useContext(
     getPrefetchContext()
   );
+  const memo = useRef();
 
   const initialState = useMemo(() => {
     return Object.keys(prefetchFunctions).reduce((total, currentKey) => {
@@ -88,7 +89,6 @@ function usePrefetch(
 
       memo.current = {
         params,
-        prefetchFunctions,
       };
     }
   }, [prefetchFunctions, initialState, params, isFirstPrefetch, memo]);
@@ -98,7 +98,7 @@ function usePrefetch(
     // probably means a new function/params, so fetch those first, then memoize them
     if (
       memo.current &&
-      !deepEqual(memo.current, { params, prefetchFunctions })
+      !deepEqual(memo.current, { params })
     ) {
       for (const key in prefetchFunctions) {
         prefetchFunctions[key](...(params[key] || []))
@@ -115,10 +115,9 @@ function usePrefetch(
 
       memo.current = {
         params,
-        prefetchFunctions,
       };
     }
-  }, [memo.current, params, prefetchFunctions]);
+  }, [memo, params, prefetchFunctions]);
 
   // for ssr prefetching
   if (requests) {

--- a/src/context.js
+++ b/src/context.js
@@ -30,9 +30,8 @@ export function getPrefetchContext() {
 
 export const PrefetchProvider = ({ data, requests, children }) => {
   const DataContext = getPrefetchContext();
-  const memo = useRef();
   return (
-    <DataContext.Provider value={{ requests, data, memo }}>
+    <DataContext.Provider value={{ requests, data }}>
       {children}
     </DataContext.Provider>
   );


### PR DESCRIPTION
- fix: fix issue where memoization constantly gets overwritten due to it being set in global level
- fix: fix refetching uses passed params rather than current params
- test: add renderWithData test cases to handle different usePrefetch usages